### PR TITLE
Use relative paths on source listings

### DIFF
--- a/package-manifest-spec.md
+++ b/package-manifest-spec.md
@@ -127,13 +127,13 @@ following keys for the following common resources.
 ### Source Files: `sources`
 
 The `sources` field defines a set of source files that comprise the source code
-for the project.  This list *should* be included in all manifests.  Package
-managers *should* use this field to inform population of the `sources` field in
+for the project.  This list **should** be included in all manifests.  Package
+managers **should** use this field to inform population of the `sources` field in
 the *release lock file*.
 
 * Key: `sources`
 * Type: List of Strings
-* Format: Strings *should* be formatted as valid filesystem paths or glob patterns, and be relative to the base directory of the package (i.e., location of epm.json)
+* Format: Strings **must** be formatted as valid filesystem paths.  All paths **must** be relative paths beginning with `./`.  All paths **must** resolve to to a path located within the base directory of the package (i.e., the location of `epm.json`)
 
 
 ### Contracts: `contracts`

--- a/package-manifest-spec.md
+++ b/package-manifest-spec.md
@@ -133,7 +133,7 @@ the *release lock file*.
 
 * Key: `sources`
 * Type: List of Strings
-* Format: Strings *should* be formatted as valid filesystem paths or glob patterns.
+* Format: Strings *should* be formatted as valid filesystem paths or glob patterns, and be relative to the base directory of the package (i.e., location of epm.json)
 
 
 ### Contracts: `contracts`


### PR DESCRIPTION
Couple things:

1. I don't think it makes sense to allow absolute paths here, as that makes package manifests environment specific (something we don't want to encourage);
1. If you assume the above to be true, this means we want relative paths -- I'd argue these paths should be relative to the location of the package manifest (`epm.json` file).

Technically someone could still use `../../../` etc. to get out, but at least we know how to resolve those if it's relative to the `epm.json` file.